### PR TITLE
Fixes #52

### DIFF
--- a/src/main/java/com/github/blutorange/maven/plugin/closurecompiler/common/FileProcessConfig.java
+++ b/src/main/java/com/github/blutorange/maven/plugin/closurecompiler/common/FileProcessConfig.java
@@ -9,15 +9,17 @@ public class FileProcessConfig {
   private final int bufferSize;
   private final String lineSeparator;
   private final SkipMode skipMode;
+  private final String outputFilename;
 
   public FileProcessConfig(String lineSeparator, int bufferSize, boolean force,
-      boolean skipMerge, boolean skipMinify, SkipMode skipMode) {
+      boolean skipMerge, boolean skipMinify, SkipMode skipMode, String outputFilename) {
     this.lineSeparator = lineSeparator;
     this.bufferSize = bufferSize;
     this.force = force;
     this.skipMerge = skipMerge;
     this.skipMinify = skipMinify;
     this.skipMode = skipMode;
+    this.outputFilename = outputFilename;
   }
 
   public boolean isSkipMerge() {
@@ -42,5 +44,9 @@ public class FileProcessConfig {
 
   public String getLineSeparator() {
     return lineSeparator;
+  }
+
+  public String getOutputFilename() {
+    return outputFilename;
   }
 }

--- a/src/main/java/com/github/blutorange/maven/plugin/closurecompiler/plugin/MinifyMojo.java
+++ b/src/main/java/com/github/blutorange/maven/plugin/closurecompiler/plugin/MinifyMojo.java
@@ -586,7 +586,7 @@ public class MinifyMojo extends AbstractMojo {
    * resulting merged file is called {@code script.min.js}.
    * @since 2.0.0
    */
-  @Parameter(property = "outputFileName", defaultValue = "#{path}/#{basename}.min.#{extension}")
+  @Parameter(property = "outputFilename", defaultValue = "#{path}/#{basename}.min.#{extension}")
   private String outputFilename;
 
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
@@ -664,7 +664,7 @@ public class MinifyMojo extends AbstractMojo {
   private ProcessFilesTask createJSTask(ClosureConfig closureConfig,
       List<String> includes, List<String> excludes, String outputFilename)
       throws IOException {
-    FileProcessConfig processConfig = new FileProcessConfig(lineSeparator, bufferSize, force, skipMerge, skipMinify, skipMode);
+    FileProcessConfig processConfig = new FileProcessConfig(lineSeparator, bufferSize, force, skipMerge, skipMinify, skipMode, outputFilename);
     FileSpecifier fileSpecifier = new FileSpecifier(baseSourceDir, baseTargetDir, sourceDir, targetDir, includes, excludes, outputFilename);
     MojoMetadata mojoMeta = new MojoMetaImpl(project, getLog(), encoding, buildContext);
     return new ProcessJSFilesTask(mojoMeta, processConfig, fileSpecifier, closureConfig);

--- a/src/main/java/com/github/blutorange/maven/plugin/closurecompiler/plugin/ProcessFilesTask.java
+++ b/src/main/java/com/github/blutorange/maven/plugin/closurecompiler/plugin/ProcessFilesTask.java
@@ -245,13 +245,13 @@ public abstract class ProcessFilesTask implements Callable<Object> {
     }
     // Merge-only
     else if (processConfig.isSkipMinify()) {
-      File mergedFile = outputFilenameInterpolator.interpolate(new File(targetDir, DEFAULT_MERGED_FILENAME), targetDir, targetDir);
+      File mergedFile = outputFilenameInterpolator.interpolate(new File(targetDir, processConfig.getOutputFilename()), targetDir, targetDir);
       results.add(merge(mergedFile));
       mojoMeta.getLog().info("Skipping the minify step...");
     }
     // Minify + merge
     else {
-      File minifiedFile = outputFilenameInterpolator.interpolate(new File(targetDir, DEFAULT_MERGED_FILENAME), targetDir, targetDir);
+      File minifiedFile = outputFilenameInterpolator.interpolate(new File(targetDir, processConfig.getOutputFilename()), targetDir, targetDir);
       results.add(minify(files, minifiedFile));
     }
 


### PR DESCRIPTION
outputFilename should be used as the final minified and merged filename,
rather than the default of script.js being forced.